### PR TITLE
Install missing python modules via pip

### DIFF
--- a/install
+++ b/install
@@ -16,6 +16,26 @@ then
     exit 1
 fi
 
+if ! sudo pip install six
+then
+    exit 1
+fi
+
+if ! sudo pip install urllib3
+then
+    exit 1
+fi
+
+if ! sudo pip install packaging
+then
+    exit 1
+fi
+
+if ! sudo pip install appdirs
+then
+    exit 1
+fi
+
 if ! sudo pip install setuptools --no-use-wheel --upgrade
 then
     exit 1


### PR DESCRIPTION
 * six, urllib3 and packaging
 * May have been previously installed as deps of other packages, but not anymore?